### PR TITLE
Fix validate_jwt function

### DIFF
--- a/src/main/python/fusionauth/fusionauth_client.py
+++ b/src/main/python/fusionauth/fusionauth_client.py
@@ -2173,7 +2173,7 @@ class FusionAuthClient:
             encoded_jwt: The encoded JWT (access token).
         """
         return self.start().uri('/api/jwt/validate') \
-            .authorization("_jwt " + encoded_jwt) \
+            .authorization("JWT " + encoded_jwt) \
             .get() \
             .go()
 


### PR DESCRIPTION
Adding "JWT " to the front of the token instead of the previous "_jwt " which was wrong and was making the validate_jwt function fail even with the right JWT token